### PR TITLE
Bugfix: wrong --crop params notation

### DIFF
--- a/src/PHPZxing/PHPZxingDecoder.php
+++ b/src/PHPZxing/PHPZxingDecoder.php
@@ -121,7 +121,7 @@ class PHPZxingDecoder extends PHPZxingBase  {
                 }
 
                 if($this->crop != false) {
-                    $command = $command . "--crop=" . $this->crop . $this->SPACE;
+                    $command = $command . "--crop " . $this->crop . $this->SPACE;
                 }
 
                 if ($this->possible_formats != false) {
@@ -151,7 +151,7 @@ class PHPZxingDecoder extends PHPZxingBase  {
         }
 
         if($this->crop != false) {
-            $command = $command . "--crop=" . $this->crop . $this->SPACE;
+            $command = $command . "--crop " . $this->crop . $this->SPACE;
         }
 
         if ($this->possible_formats != false) {

--- a/src/examples/example.php
+++ b/src/examples/example.php
@@ -67,7 +67,7 @@ authors:
     // Bar Code Options
     $config = array(
         'try_harder'            => true,
-        'crop'                  => '100,200,300,300',
+        'crop'                  => '100 200 300 300',
     );
     $decoder        = new PHPZxingDecoder($config);
     $decodedArray   = $decoder->decode('../images');


### PR DESCRIPTION
I've found that "--crop=left,top,width,height" notation not working (it's causing java exeption for me).
Maybe its because of adding JCommander some time ago.
Changing to "--crop left top width height" saved the day.